### PR TITLE
KURSP-872: handle warnings

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,5 +1,5 @@
 server {
-    
+
     server_name NGINX_SERVER_NAME	;
     listen 443 ssl default_server;
     listen [::]:443 ssl default_server;
@@ -21,6 +21,13 @@ server {
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {
         root   /usr/share/nginx/html;
+    }
+
+    # skip favicon.ico
+    #
+    location = /favicon.ico {
+        access_log off;
+        return 204;
     }
 
     # proxy the PHP scripts to Apache listening on 127.0.0.1:80
@@ -46,4 +53,3 @@ server {
     #    deny  all;
     #}
 }
-

--- a/statistics_api/clients/canvas_api_client.py
+++ b/statistics_api/clients/canvas_api_client.py
@@ -74,6 +74,7 @@ class CanvasApiClient:
         if web_response.status_code in (401, 403):
             print("Response code not 200 ", web_response.status_code)
             print(target_url)
+            print(web_response.text)
             return None
         if web_response.status_code != 200:
             print(web_response)

--- a/statistics_api/settings.py
+++ b/statistics_api/settings.py
@@ -67,6 +67,15 @@ MIDDLEWARE = [
 
 ROOT_URLCONF = 'statistics_api.urls'
 
+REST_FRAMEWORK = {
+    'DEFAULT_RENDERER_CLASSES': [
+        'rest_framework.renderers.JSONRenderer',
+    ],
+    'DEFAULT_PARSER_CLASSES': [
+        'rest_framework.parsers.JSONParser',
+    ]
+}
+
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',

--- a/statistics_api/urls.py
+++ b/statistics_api/urls.py
@@ -17,6 +17,7 @@ Including another URLconf
 from django.urls import re_path as url
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
+from django.shortcuts import redirect
 
 from statistics_api.controllers.high_schools_county_controller import county_high_school_statistics_by_county_id
 from statistics_api.controllers.primary_schools_controller import municipality_primary_school_statistics, \
@@ -59,4 +60,6 @@ urlpatterns = [
     url(r'^version/?$', get_software_version),
 
     path("api/statistics/", include(router.urls)),
+    path("", lambda req: redirect('api/statistics', permanent=False)),
+
 ]


### PR DESCRIPTION
use jsonRenderer as default, make root a valid endpoint to avoid warnings being caused by Azure AlwaysOn, remove favicon warning