### PR TITLE
Remove hardcoded dependency on system having the eth0 network interface to get system ip_address

### DIFF
--- a/statistics_api/definitions.py
+++ b/statistics_api/definitions.py
@@ -1,7 +1,23 @@
 import os
+import socket
 from distutils import util
 import netifaces as ni
 from sqlalchemy.ext.declarative import declarative_base
+
+def get_ip_address():
+    if 'eth0' in ni.interfaces():
+        ip = ni.ifaddresses('eth0').get(ni.AF_INET)
+        return ip[0]['addr']
+    else:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        
+        try:
+            s.connect(("8.8.8.8", 80))
+            ip_address = s.getsockname()[0]
+        finally:
+            s.close()
+        
+        return ip_address
 
 ####    START OF ENVIRONMENT VARIABLES  ####
 
@@ -41,10 +57,9 @@ allowed_hosts = [s.strip() for s in os.getenv("DJANGO_ALLOWED_HOSTS", "").split(
 if not allowed_hosts:
     allowed_hosts = ["*"]
 
-ni.ifaddresses('eth0')
-ip = ni.ifaddresses('eth0')[ni.AF_INET][0]['addr']
-
+ip = get_ip_address()
 allowed_hosts.append(ip)
+allowed_hosts.append("127.0.0.1")
 
 DJANGO_ALLOWED_HOSTS = allowed_hosts
 


### PR DESCRIPTION
- Updated method to get ip address so that it has a fallback method if eth0 does not exist
- Added 127.0.0.1 by default to the allowed_hosts in case ip address is something else